### PR TITLE
Gets the recurrencewidget to a usable state.

### DIFF
--- a/plonetheme/onegov/resources/css/main.css
+++ b/plonetheme/onegov/resources/css/main.css
@@ -2201,6 +2201,45 @@ ul li#document-action-kml_download {
 
 /* @end */
 /* @end */
+/* @group jquery.recurrenceinput.js */
+/*
+    jquery.recurrenceinput.js has it's own css which does not play well with
+    sunburst. It needs quite the fix-up to be usable.
+*/
+/* the headers are too big and prominent */
+div.riform h1,
+#rirtemplate h2 {
+  color: #32444a;
+  font-size: 138.46%; }
+
+/* the lower headers have different distances to their borders */
+div.riform h1,
+#rirtemplate div.rioccurancesheader {
+  padding-bottom: 0.25em;
+  border-color: #e5e5e0; }
+
+/* the font is too small */
+#rirtemplate,
+div.riform,
+#rirtemplate .batching,
+#rirtemplate .start .rlabel {
+  font-size: 13px; }
+
+/* the small 'beginning of recurrence'-label is unreadable and positioned awfully*/
+#rirtemplate .start .rlabel {
+  color: #7e7e7e;
+  font-weight: normal !important;
+  float: right;
+  position: relative; }
+
+/* the fields are smashed too close together */
+#riformfields .label, #riformfields .field {
+  margin-top: 1em; }
+
+#rirangeoptions div {
+  margin-bottom: 1em; }
+
+/* @end */
 /* @group checkbox and radio */
 input[type="checkbox"],
 input[type="radio"] {

--- a/plonetheme/onegov/resources/sass/components/recurrencewidget.scss
+++ b/plonetheme/onegov/resources/sass/components/recurrencewidget.scss
@@ -1,0 +1,47 @@
+/* @group jquery.recurrenceinput.js */
+
+/*
+    jquery.recurrenceinput.js has it's own css which does not play well with
+    sunburst. It needs quite the fix-up to be usable.
+*/
+
+/* the headers are too big and prominent */
+div.riform h1,
+#rirtemplate h2 {
+    color: $text-color;
+    font-size: $font-size-18;
+}
+
+/* the lower headers have different distances to their borders */
+div.riform h1,
+#rirtemplate div.rioccurancesheader {
+    padding-bottom: 0.25em;
+    border-color: $lightgray2;
+}
+
+/* the font is too small */
+#rirtemplate,
+div.riform,
+#rirtemplate .batching,
+#rirtemplate .start .rlabel {
+    font-size: $font-size;
+}
+
+/* the small 'beginning of recurrence'-label is unreadable and positioned awfully*/
+#rirtemplate .start .rlabel {
+    color: $text-color-light;   
+    font-weight: normal !important;
+    float: right;
+    position: relative;
+}
+
+/* the fields are smashed too close together */
+#riformfields .label, #riformfields .field {
+    margin-top: 1em;
+}
+
+#rirangeoptions div {
+    margin-bottom: 1em;   
+}
+
+/* @end */

--- a/plonetheme/onegov/resources/sass/main.scss
+++ b/plonetheme/onegov/resources/sass/main.scss
@@ -26,5 +26,6 @@ sass --watch sass/main.scss:css/main.css
   "components/responsive.scss",
   "components/directory.scss",
   "components/events.scss",
+  "components/recurrencewidget.scss",
   "components/overrides.scss",
   "components/overrides_zug.scss"


### PR DESCRIPTION
The jquery.recurrenceinput.js looks awful on sunburst to the point of
being broken. This commit fixes the worst problems with it, making
it fit much better into plonetheme.onegov.
