### PR TITLE
Add a ".bookReaderLastElement" div so that ftw.book's reader works.

### DIFF
--- a/plonetheme/onegov/resources/index.html
+++ b/plonetheme/onegov/resources/index.html
@@ -258,6 +258,8 @@
         <ul id="portal-siteactions" />
       </div>
 
+      <div class="bookReaderLastElement"></div>
+
       <!-- closes #container -->
     </div>
 


### PR DESCRIPTION
The reader needs to detect the page size and calculate the height it can use
for the reader so that scrolling works well and as most space as possible is
used for the reader area.

@ninfaj I've added a separate `<div>` for making it more explicit on further changes.
