### PR TITLE
Diazo Transform is very slow on pages with many links

### DIFF
--- a/plonetheme/onegov/resources/rules.xml
+++ b/plonetheme/onegov/resources/rules.xml
@@ -59,30 +59,6 @@
     <replace css:content-children="div.documentActions" css:theme-children="#document-actions" />
     <drop css:content="div.documentActions" />
 
-    <!-- document actions: use icon font:
-         - move the text-content to the title attribute
-         - replace the text-content with the one-charactor icon code for the icon font -->
-    <replace css:content-children="#document-action-print a">
-        <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>5
-    </replace>
-    <replace css:content-children="#document-action-watch a">
-        <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>C
-    </replace>
-    <replace css:content-children="#document-action-addtofavourites a">
-        <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>*
-    </replace>
-    <replace css:content-children="#document-action-addtofavorites a">
-        <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>*
-    </replace>
-    <replace css:content-children="#document-action-pdf a">
-        <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>&#x22;
-    </replace>
-    <replace css:content-children="#document-action-reader a">
-        <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>&#x60;
-    </replace>
-
-
-
     <!-- copy missing accesskeys -->
     <replace css:theme-children="#accesskeys" css:content="a[accesskey='2'], a[accesskey='6']" />
 

--- a/plonetheme/onegov/resources/sass/components/base.scss
+++ b/plonetheme/onegov/resources/sass/components/base.scss
@@ -156,7 +156,6 @@ a,
   @include ul($style: 'inline');
   float: right;
   & li a {
-    font-family: 'icomoon';
     font-size: 1.5em;
     margin-left: 0.25em;
     text-decoration: none;

--- a/plonetheme/onegov/resources/sass/components/icons.scss
+++ b/plonetheme/onegov/resources/sass/components/icons.scss
@@ -197,3 +197,52 @@ a.external-link {
     vertical-align: middle;
   }
 }
+
+
+/* @group document actions */
+
+#document-action-print a {
+  @include icon($char: "5 ");
+}
+#document-action-watch a {
+  @include icon($char: "C ");
+}
+#document-action-addtofavourites a {
+  @include icon($char: "* ");
+}
+#document-action-addtofavorites a {
+  @include icon($char: "* ");
+}
+#document-actions #document-action-pdf a {
+  @include icon($char: "` ");
+}
+#document-actions #document-action-reader a {
+  @include icon($char: '" ');
+}
+
+#document-actions #document-action-print a,
+#document-actions #document-action-watch a,
+#document-actions #document-action-addtofavourites a,
+#document-actions #document-action-addtofavorites a,
+#document-actions #document-action-pdf a,
+#document-actions #document-action-reader a {
+  font-size: 1px;
+  color: transparent;
+  width: 20px;
+  margin: 0 3px;
+  height: 20px;
+  overflow: hidden;
+  display: block;
+  float: left;
+  &:before {
+    font-size: 20px;
+    color: $link-color;
+  }
+  &:hover {
+    &:before {
+      color: $link-color-hover;
+    }
+  }
+}
+
+/* @end */


### PR DESCRIPTION
I've been puzzled by how slow the theme is on certain pages since and I've finally found the cause (though not yet the solution). I have a page that may contain a lot of links depending on the pagination.

Since using plonetheme.onegov the rendering time has gone up from 500ms to 3000ms. Turns out that the cause of this delay is the following part in the rules.xml:

```
<!-- document actions: use icon font:
     - move the text-content to the title attribute
     - replace the text-content with the one-charactor icon code for the icon font -->
<replace css:content-children="#document-action-print a">
    <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>5
</replace>
<replace css:content-children="#document-action-watch a">
    <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>C
</replace>
<replace css:content-children="#document-action-addtofavourites a">
    <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>*
</replace>
<replace css:content-children="#document-action-addtofavorites a">
    <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>*
</replace>
<replace css:content-children="#document-action-pdf a">
    <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>&#x22;
</replace>
<replace css:content-children="#document-action-reader a">
    <xsl:attribute name="title"><xsl:value-of select="text()" /></xsl:attribute>&#x60;
</replace>
```

Without it the theme transform is barely measurable. With it, the site slows to a crawl. I tried changing the selectors to xpath expressions - those are generally faster - but to no avail. As of yet I don't have a solution, but I didn't spend to much time investigating either.

It's probably necessary to not select on the links ('#document-action-pdf a'), but the ids alone ('#document-actions'). That will speed things up a lot. XSLT has the ability to copy the current node it selects and modify it (`<xsl:copy>`) - so the a-element doesn't need to be selected directly.

To test create a plone page and add a couple of hundred links to it using copy paste in the html editor.
