### PR TITLE
Renders the lists in seantis.people table and detail view denser.

### DIFF
--- a/plonetheme/onegov/resources/sass/components/people.scss
+++ b/plonetheme/onegov/resources/sass/components/people.scss
@@ -1,5 +1,14 @@
 /* @group seantis.people */
 
+/* @group field rendering */
+.portaltype-seantis-people-list table,
+.person-details {
+    ul li {
+        margin-bottom: 0;
+    }
+}
+/* @end*/
+
 /* @group list filter */
 .portaltype-seantis-people-list {
 


### PR DESCRIPTION
I've been wondering, would it make sense to have a couple of helper classes to style common elements? For example. A .tag class could activate the tag from the mixins. A 'dense' class could be used below, instead of a very specific style.

So instead of this pull request, I would just render my ul elements like this:

```
<ul class="dense"></ul>
```

Relying on something like this:

```
.dense {
    margin-bottom: 0;
}
```

What do you think @ninfaj?
