### PR TITLE
Use a grid without margin in the content area.

### DIFF
--- a/plonetheme/onegov/resources/sass/components/grid.scss
+++ b/plonetheme/onegov/resources/sass/components/grid.scss
@@ -88,3 +88,20 @@ div.position-14  { @include position14(); }
 div.position-15  { @include position15(); }
 
 /* @end */
+
+/* @group grid in content */
+
+#column-content {
+  @for $i from 1 through 16 {
+    div.width-#{$i} {
+      width: percentage((100 / 16) * $i)/100;
+    }
+  }
+  @for $i from 0 through 15 {
+    div.position-#{$i} {
+      margin-left: percentage((100 / 16) * $i)/100 - 100;
+    }
+  }
+}
+
+/* @end */


### PR DESCRIPTION
There is a problem with the layout (extra margin) if the grid is used in the content area.

I've removed the margins if the grid is in the `#column-content`.

![bildschirmfoto 2013-11-25 um 10 49 04](https://f.cloud.github.com/assets/157533/1611844/477d96ee-55b7-11e3-9d7e-ec5f381704ab.png)

![bildschirmfoto 2013-11-25 um 10 48 47](https://f.cloud.github.com/assets/157533/1611843/47664b1a-55b7-11e3-88c9-55b5a2d59033.png)

@href please take a look
fixes #41 
