### PR TITLE
Make sure the onegov batching template is loaded.

### DIFF
--- a/plonetheme/onegov/browser/batching.py
+++ b/plonetheme/onegov/browser/batching.py
@@ -4,4 +4,4 @@ from plone.batching import browser
 
 class BatchView(browser.PloneBatchView):
 
-    template = ViewPageTemplateFile('batchnavigation.pt')
+    index = template = ViewPageTemplateFile('batchnavigation.pt')

--- a/plonetheme/onegov/tests/test_batching.py
+++ b/plonetheme/onegov/tests/test_batching.py
@@ -1,0 +1,31 @@
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.batching import Batch
+from plone.browserlayer.layer import mark_layer
+from plonetheme.onegov.testing import THEME_FUNCTIONAL_TESTING
+from pyquery import PyQuery
+from unittest2 import TestCase
+from zope.traversing.interfaces import BeforeTraverseEvent
+
+
+class TestReindering(TestCase):
+
+    layer = THEME_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        mark_layer(self.portal,
+                   BeforeTraverseEvent(self.portal, self.request))
+
+    def test_custom_batching_is_available(self):
+        batch = Batch.fromPagenumber([item for item in range(1, 100)],
+                                    pagesize=10,
+                                    pagenumber=1)
+
+        batching = self.portal.restrictedTraverse('@@batchnavigation')
+
+        doc = PyQuery(batching(batch))
+        self.assertTrue(doc('.onegovBatching.listingBar'),
+                        'Did not found the onegov batching')

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ tests_require = [
     'plone.app.testing',
     'plone.resource',
     'unittest2',
+    'pyquery',
     ]
 
 setup(name='plonetheme.onegov',


### PR DESCRIPTION
Compatibility for Plone 4.3, 4.3.1, 4.3.2
With plone 4.3.2 the batching template is stored in `index` not in `template`. 
Now it's stored in both. 

I also added ad test. 
