### PR TITLE
Customstyles: fix meta image inclusion (favicons, apple touch icons).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Customstyles: fix meta image inclusion (favicons, apple touch icons).
+  [jone]
+
 - Fix customstyles caching reset bug when modifying existing configurations.
   [jone]
 

--- a/plonetheme/onegov/resources/rules.xml
+++ b/plonetheme/onegov/resources/rules.xml
@@ -36,9 +36,6 @@
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=1.0" />
     </replace>
 
-    <!-- copy links from onegov meta viewlet -->
-    <after theme-children="/html/head" css:content="#portal-header > link" />
-
     <!-- copy styles and javascripts in portal-top -->
     <replace css:content="#portal-top style, #portal-top script"
              css:theme-children="#portal-top" />

--- a/plonetheme/onegov/tests/test_meta_viewlet.py
+++ b/plonetheme/onegov/tests/test_meta_viewlet.py
@@ -1,0 +1,76 @@
+from ftw.testbrowser import browsing
+from plonetheme.onegov.interfaces import ICustomStyles
+from plonetheme.onegov.testing import THEME_FUNCTIONAL_TESTING
+from unittest2 import TestCase
+import transaction
+
+
+class TestMetaViewlet(TestCase):
+    layer = THEME_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    @browsing
+    def test_default_favicon(self, browser):
+        browser.open()
+        tag = browser.css('link[type="image/x-icon"]').first
+        self.assertEquals('http://nohost/plone/favicon.ico',
+                          tag.attrib.get('href'))
+
+    @browsing
+    def test_favicon_config(self, browser):
+        ICustomStyles(self.portal).set('img.favicon', '%PORTAL_URL%/my-fav.ico')
+        transaction.commit()
+        browser.open()
+        tag = browser.css('link[type="image/x-icon"]').first
+        self.assertEquals('/plone/my-fav.ico',
+                          tag.attrib.get('href'))
+
+    @browsing
+    def test_startup_image_config(self, browser):
+        ICustomStyles(self.portal).set('img.startup', '%PORTAL_URL%/s.png')
+        transaction.commit()
+        browser.open()
+        tag = browser.css('link[rel="apple-touch-startup-image"]').first
+        self.assertEquals('/plone/s.png',
+                          tag.attrib.get('href'))
+
+    @browsing
+    def test_touch_iphone_config(self, browser):
+        ICustomStyles(self.portal).set('img.touch_iphone', '%PORTAL_URL%/t.png')
+        transaction.commit()
+        browser.open()
+        tag = browser.css('link[rel="apple-touch-icon"]').first
+        self.assertEquals('/plone/t.png',
+                          tag.attrib.get('href'))
+
+    @browsing
+    def test_touch_iphone_76_config(self, browser):
+        ICustomStyles(self.portal).set('img.touch_iphone_76',
+                                       '%PORTAL_URL%/t76.png')
+        transaction.commit()
+        browser.open()
+        tag = browser.css('link[rel="apple-touch-icon"][sizes="76x76"]').first
+        self.assertEquals('/plone/t76.png',
+                          tag.attrib.get('href'))
+
+    @browsing
+    def test_touch_iphone_120_config(self, browser):
+        ICustomStyles(self.portal).set('img.touch_iphone_120',
+                                       '%PORTAL_URL%/t120.png')
+        transaction.commit()
+        browser.open()
+        tag = browser.css('link[rel="apple-touch-icon"][sizes="120x120"]').first
+        self.assertEquals('/plone/t120.png',
+                          tag.attrib.get('href'))
+
+    @browsing
+    def test_touch_iphone_152_config(self, browser):
+        ICustomStyles(self.portal).set('img.touch_iphone_152',
+                                       '%PORTAL_URL%/t152.png')
+        transaction.commit()
+        browser.open()
+        tag = browser.css('link[rel="apple-touch-icon"][sizes="152x152"]').first
+        self.assertEquals('/plone/t152.png',
+                          tag.attrib.get('href'))

--- a/plonetheme/onegov/viewlets/configure.zcml
+++ b/plonetheme/onegov/viewlets/configure.zcml
@@ -20,10 +20,9 @@
       layer="plonetheme.onegov.interfaces.IPlonethemeOneGovLayer"
       />
 
-  <!-- meta viewlet -->
   <browser:viewlet
-      name="onegov.meta"
-      manager="plone.app.layout.viewlets.interfaces.IPortalHeader"
+      name="plone.links.favicon"
+      manager="plone.app.layout.viewlets.interfaces.IHtmlHeadLinks"
       class=".meta.MetaViewlet"
       permission="zope2.View"
       layer="plonetheme.onegov.interfaces.IPlonethemeOneGovLayer"

--- a/plonetheme/onegov/viewlets/meta.py
+++ b/plonetheme/onegov/viewlets/meta.py
@@ -1,9 +1,8 @@
-from BTrees.OOBTree import OOBTree
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone.app.layout.navigation.root import getNavigationRoot
 from plone.app.layout.viewlets import common
+from plonetheme.onegov.interfaces import ICustomStyles
 from plonetheme.onegov.utils import replace_custom_keywords
-from zope.annotation.interfaces import IAnnotations
 
 
 class MetaViewlet(common.LogoViewlet):
@@ -12,11 +11,12 @@ class MetaViewlet(common.LogoViewlet):
 
     def update(self):
         super(MetaViewlet, self).update()
-        annotations = IAnnotations(self.context.restrictedTraverse(
-                getNavigationRoot(self.context)))
-        self.customstyles = annotations.get('customstyles', OOBTree({}))
+        navroot = self.context.restrictedTraverse(
+            getNavigationRoot(self.context))
+        self.customstyles = ICustomStyles(navroot).get_styles()
 
-        self.favicon = self.customstyle_value('img.favicon')
+        self.favicon = self.customstyle_value('img.favicon') or \
+            '/'.join((navroot.absolute_url(), 'favicon.ico'))
         self.startup = self.customstyle_value('img.startup')
         self.touch_iphone = self.customstyle_value('img.touch_iphone')
         self.touch_iphone_76 = self.customstyle_value('img.touch_iphone_76')


### PR DESCRIPTION
Includes these fixes:
- Use the ICustomStyles adapter - the annotation key was wrong and could never work.
- Override Plone's plone.links.favicon viewlet for not having duplicate <link>
  tags in the HTML anymore.
- Remove special handling in rules.xml which did not work anyway.

Also:
- Added tests.

@ninfaj Could you take a look?
