### PR TITLE
Navigation portlet: css-classes for workflow state and expiration

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
+- Navigation portlet: add "content-expired" class on expired items.
+  [jone]
+
 - Navigation portlet: add css class with item workflow state.
   [jone]
 

--- a/plonetheme/onegov/portlets/navigation.pt
+++ b/plonetheme/onegov/portlets/navigation.pt
@@ -31,8 +31,12 @@
       </tal:top_siblings>
 
       <li tal:content="context/Title"
-          tal:define="workflow_state context/plone_context_state/workflow_state"
-          tal:attributes="class string:current state-${workflow_state}" />
+          tal:define="is_expired context/expires/isPast|nothing;
+                      classes python: is_expired and 'content-expired' or '';
+                      workflow_state context/plone_context_state/workflow_state;
+                      classes string:state-${workflow_state} ${classes};
+                      classes python:view.cssclasses(context)"
+          tal:attributes="class string:current ${classes}" />
 
       <tal:children repeat="child children">
         <li tal:define="classes python:view.cssclasses(child)"


### PR DESCRIPTION
This PR adds two classes to items in the navigation:
1. A `state-*` class with the workflow state (e.g. `state-private`)
2. A `content-expired` class when the content is expired

This allows to highlight contents in a specific state (e.g. private or submitted) or expired content for editors.
There is no CSS styling those classes, the CSS belongs into integration packages..
