### PR TITLE
Fix ftw.book icons: interchange "PDF" and "Read" icons.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Fix ftw.book icons: interchange "PDF" and "Read" icons.
+  [jone]
+
 - Added style for calendar portlet.
   [Julian Infanger]
 

--- a/plonetheme/onegov/resources/sass/components/icons.scss
+++ b/plonetheme/onegov/resources/sass/components/icons.scss
@@ -255,10 +255,10 @@ a.external-link {
   @include icon($char: "* ");
 }
 #document-actions #document-action-pdf a {
-  @include icon($char: "` ");
+  @include icon($char: '" ');
 }
 #document-actions #document-action-reader a {
-  @include icon($char: '" ');
+  @include icon($char: "` ");
 }
 
 #document-actions #document-action-print a,


### PR DESCRIPTION
The "PDF" and "Read" document_action icons were wrong, I've swapped them.

New:
![bildschirmfoto 2014-02-24 um 09 40 10](https://f.cloud.github.com/assets/7469/2243582/760c0760-9d2f-11e3-939b-998073d8f843.png)
