### PR TITLE
Theme not working with python 2.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ This is the default theme for all OneGov Plone modules (http://onegov.ch).
 
 .. image:: https://raw.github.com/OneGov/plonetheme.onegov/master/docs/screenshot_onegov.png
 
+**Important** this package doesn't work with python 2.6, it requires at least python 2.7
 
 Usage
 -----

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Added information that this package requires >= python2.7
+  [Julian Infanger]
+
 - Added path_bar with flyout children.
   [Julian Infanger]
 


### PR DESCRIPTION
I'm not sure if we need to support python 2.6, but it currently does not work:

``` python
....
  File "/Users/jone/projects/python/cache/eggs/zope.viewlet-3.7.2-py2.6.egg/zope/viewlet/manager.py", line 118, in _updateViewlets
    viewlet.update()
  File "/Users/jone/projects/izug/izug.onegov/src/plonetheme.onegov/plonetheme/onegov/viewlets/customstyles.py", line 43, in update
    self.customstyles = self.generate_css()
  File "/Users/jone/projects/python/cache/eggs/plone.memoize-1.1.1-py2.6.egg/plone/memoize/volatile.py", line 276, in replacement
    key = get_key(fun, *args, **kwargs)
  File "/Users/jone/projects/izug/izug.onegov/src/plonetheme.onegov/plonetheme/onegov/viewlets/customstyles.py", line 19, in cache_key
    cachekey_prefix = '{}.{}'.format(self.__name__, method.__name__)
ValueError: zero length field name in format
```

I think we should either fix the obvious problems, such as this cache formating, or we should indicate in the readme that we do not support python 2.6..
