### PR TITLE
Append "/view" to objects in left navigation...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Append "/view" to objects in left navigation if they are in the
+  'typesUseViewActionInListings' property.
+  [Julian Infanger]
+
 - Added styles for news archive portlet.
   [Julian Infanger]
 

--- a/plonetheme/onegov/portlets/navigation.pt
+++ b/plonetheme/onegov/portlets/navigation.pt
@@ -24,7 +24,7 @@
       <tal:top_siblings tal:repeat="sibling siblings/before_context|nothing">
           <li tal:define="classes python:view.cssclasses(sibling)"
               tal:attributes="class string:sibling beforeContext ${classes}">
-              <a tal:attributes="href sibling/getURL;
+              <a tal:attributes="href python:view.url(sibling);
                                  title sibling/Title"
                  tal:content="sibling/Title"/>
           </li>
@@ -41,7 +41,7 @@
       <tal:children repeat="child children">
         <li tal:define="classes python:view.cssclasses(child)"
             tal:attributes="class string:child ${classes}">
-          <a tal:attributes="href child/getURL;
+          <a tal:attributes="href python:view.url(child);
                              title child/Title"
              tal:content="child/Title"
              />
@@ -51,7 +51,7 @@
       <tal:bottom_siblings tal:repeat="sibling siblings/after_context|nothing">
           <li tal:define="classes python:view.cssclasses(sibling)"
               tal:attributes="class string:sibling afterContext ${classes}">
-              <a tal:attributes="href sibling/getURL;
+              <a tal:attributes="href python:view.url(sibling);
                                  title sibling/Title"
                  tal:content="sibling/Title"/>
           </li>

--- a/plonetheme/onegov/portlets/navigation.py
+++ b/plonetheme/onegov/portlets/navigation.py
@@ -30,6 +30,8 @@ class Renderer(base.Renderer):
 
         properties = getToolByName(self.context, 'portal_properties')
         self.hidden_types = properties.navtree_properties.metaTypesNotToList
+        self.view_action_types = properties.site_properties.getProperty(
+            'typesUseViewActionInListings', ())
 
     def show_parent(self):
         """ Do not show parent if you are on navigationroot.
@@ -65,6 +67,11 @@ class Renderer(base.Renderer):
 
     def children(self):
         return self.filter_brains(self.context.getFolderContents())
+
+    def url(self, brain):
+        if brain.portal_type in self.view_action_types:
+            return brain.getURL() + '/view'
+        return brain.getURL()
 
     def filter_brains(self, brains):
         """Filters brains, removing ignored types and content excluded from

--- a/plonetheme/onegov/tests/test_navigation_portlet.py
+++ b/plonetheme/onegov/tests/test_navigation_portlet.py
@@ -45,6 +45,33 @@ class TestNavigationPortlet(TestCase):
         self.assertEquals('The Folder', portlet().css('.current').first.text)
 
     @browsing
+    def test_append_view_to_link_if_type_in_property(self, browser):
+        create(Builder('navigation portlet'))
+        folder = create(Builder('folder').titled('The Folder'))
+
+        properties = getToolByName(self.portal, 'portal_properties')
+        properties.site_properties.typesUseViewActionInListings=('Image')
+
+        create(Builder('image').titled('my-image').within(folder))
+        browser.visit(folder)
+        self.assertEqual('http://nohost/plone/the-folder/my-image/view',
+                         portlet().css('li.child > a').first.attrib.get('href'))
+
+    @browsing
+    def test_dont_append_view_to_link_if_type_in_property(self, browser):
+        create(Builder('navigation portlet'))
+        folder = create(Builder('folder').titled('The Folder'))
+
+        properties = getToolByName(self.portal, 'portal_properties')
+        properties.site_properties.typesUseViewActionInListings=()
+
+        create(Builder('image').titled('my-image').within(folder))
+        browser.visit(folder)
+
+        self.assertEqual('http://nohost/plone/the-folder/my-image',
+                         portlet().css('li.child > a').first.attrib.get('href'))
+
+    @browsing
     def test_lists_children(self, browser):
         create(Builder('navigation portlet'))
         folder = create(Builder('folder').titled('The Folder'))


### PR DESCRIPTION
...if they are in the 'typesUseViewActionInListings' property.

This fixes the problem with images in the navigation portlet which were opened directly.
It's implemented like the plone default navigation portlet behaviour.

@elioschmutz would you take a look at this please?
