### PR TITLE
Improve default page support in navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
+- Do not show default pages in navigation.
+  If the parent is a default page, show the default page title.
+  [jone]
+
 - Fixed skins properties.
   Do not longer inject skin layer into all skins.
   [Julian Infanger]

--- a/plonetheme/onegov/portlets/navigation.pt
+++ b/plonetheme/onegov/portlets/navigation.pt
@@ -1,7 +1,6 @@
 <dl class="portlet portletContextNavigation"
     i18n:domain="plonetheme.onegov"
-    tal:define="parent nocall:view/parent;
-                children view/children;
+    tal:define="children view/children;
                 siblings view/siblings">
 
   <dt class="portletHeader hiddenStructure">
@@ -13,10 +12,10 @@
   <dd class="portletItem">
     <ul>
       <tal:parent condition="view/show_parent">
-        <li class="parent">
-          <a tal:attributes="href parent/absolute_url;
-                             title parent/Title"
-             tal:content="parent/Title"
+        <li class="parent" tal:define="link view/parent_link">
+          <a tal:attributes="href link/url;
+                             title link/title"
+             tal:content="link/title"
              />
         </li>
       </tal:parent>

--- a/plonetheme/onegov/portlets/navigation.py
+++ b/plonetheme/onegov/portlets/navigation.py
@@ -4,6 +4,8 @@ from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
 from Products.CMFPlone.utils import base_hasattr
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from borg.localrole.interfaces import IFactoryTempFolder
+from plone.app.layout.navigation.defaultpage import getDefaultPage
+from plone.app.layout.navigation.defaultpage import isDefaultPage
 from plone.app.portlets.portlets import base
 from plone.app.portlets.portlets.navigation import getRootPath
 from plone.memoize.instance import memoize
@@ -43,6 +45,17 @@ class Renderer(base.Renderer):
             return False
         return True
 
+    def parent_link(self):
+        if getDefaultPage(self.parent):
+            page = self.parent.unrestrictedTraverse(
+                getDefaultPage(self.parent))
+            return {'title': page.Title(),
+                    'url': self.parent.absolute_url()}
+
+        else:
+            return {'title': self.parent.Title(),
+                    'url': self.parent.absolute_url()}
+
     def siblings(self):
         if self.data.currentFolderOnly:
             return None
@@ -56,6 +69,9 @@ class Renderer(base.Renderer):
         for brain in parent.getFolderContents():
             if brain.getPath() == context_path:
                 context_reached = True
+                continue
+            obj = brain.getObject()
+            if isDefaultPage(aq_parent(aq_inner(obj)), obj):
                 continue
             if not context_reached:
                 before.append(brain)

--- a/plonetheme/onegov/tests/test_navigation_portlet.py
+++ b/plonetheme/onegov/tests/test_navigation_portlet.py
@@ -200,3 +200,26 @@ class TestNavigationPortlet(TestCase):
                              portlet().css('.current').first.classes)
             self.assertNotIn('content-expired', portlet().css('.child').first.classes)
             self.assertNotIn('content-expired', portlet().css('.sibling')[1].classes)
+
+    @browsing
+    def test_default_pages_are_not_listed(self, browser):
+        create(Builder('navigation portlet'))
+        homepage = create(Builder('page').titled('Homepage'))
+        self.portal._setProperty('default_page', homepage.getId(), 'string')
+        homepage.reindexObject()
+        other = create(Builder('page').titled('Other page'))
+
+        browser.open(self.portal)
+        self.assertFalse(portlet().css('.parent'))
+        self.assertEquals('Homepage', portlet().css('.current').first.text)
+        self.assertEquals(['Other page'], portlet().css('.sibling').text)
+
+        browser.open(homepage)
+        self.assertFalse(portlet().css('.parent'))
+        self.assertEquals('Homepage', portlet().css('.current').first.text)
+        self.assertEquals(['Other page'], portlet().css('.sibling').text)
+
+        browser.open(other)
+        self.assertEquals('Homepage', portlet().css('.parent').first.text)
+        self.assertEquals('Other page', portlet().css('.current').first.text)
+        self.assertEquals([], portlet().css('.sibling').text)


### PR DESCRIPTION
Do not show default pages in navigation.
If the parent is a default page, show the default page title (but still link to the parent).
