### PR TITLE
Fixes seantis.reservation form choices being rendered without line breaks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.2.6 (unreleased)
 ------------------
 
+- Fixes seantis.reservation form choices being rendered without line breaks.
+  [href]
+
 - Removes superfluous scrollbars in fullcalendar instances.
   [href]
 

--- a/plonetheme/onegov/resources/sass/components/reservation.scss
+++ b/plonetheme/onegov/resources/sass/components/reservation.scss
@@ -69,7 +69,6 @@
         }
     }
 }
-
 /* @end */
 
 /* @group calendar context-menu */
@@ -98,6 +97,14 @@
     position: relative;
     padding-top: 0.25em;
     padding: 0.25em 0.5em;
+}
+/* @end */
+
+/* @group reservation form */
+.seantis-reservation-form {
+    span.option {
+        display: block;
+    }
 }
 /* @end */
 


### PR DESCRIPTION
Closes #109
