### PR TITLE
pb_close.png location

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.2.8 (unreleased)
 ------------------
 
+- Fixed path of pb_close image.
+  [Julian Infanger]
+
 - Use portal_url for portal and theme url also added the portalurl to the csscachekey so we don't get problems with image.
   [tschanzt]
 

--- a/plonetheme/onegov/resources/sass/components/overlays.scss
+++ b/plonetheme/onegov/resources/sass/components/overlays.scss
@@ -14,7 +14,7 @@
 /* default close button positioned on upper-left corner */
 div.overlaybg div.close,
 div.overlay div.close {
-  background-image: url(../images/pb_close.png);
+  background-image: url(%THEME_URL%/images/pb_close.png);
   position: absolute;
   left: -14px;
   top: -14px;


### PR DESCRIPTION
I have a number of sites where pb_close.png cannot be found when defined like this:
https://github.com/OneGov/plonetheme.onegov/blob/a586c33adedd502feb32d4e9316e1fd65f2339f9/plonetheme/onegov/resources/static/static.css#L1664

It seems like most of my sites actually have pb_close.png in the root folder (host/plone/pb_close.png).

Is there something amiss with my sites?
What's the reason behind the pb_close.png location as it stands now? Why is there a relative part to it?
