### PR TITLE
Show document description blocks in seantis directories.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.2.7 (unreleased)
 ------------------
 
+- Show document description blocks in seantis directories.
+  [href]
+
 - Updated styles for book reader view.
   [Julian Infanger]
 

--- a/plonetheme/onegov/resources/sass/components/directory.scss
+++ b/plonetheme/onegov/resources/sass/components/directory.scss
@@ -12,6 +12,11 @@
 /* @group all directory views */
 .seantis-directory-all {
 
+    /* hidden by default in plonetheme.onegov */
+    .documentDescription {
+        display: block;
+    }
+
     /* search box styles */
     #directorySearch {
         background-color: $lightgray;


### PR DESCRIPTION
They are hidden in base.scss -> for the directories it makes sense to show them.
