### PR TITLE
Fix small style issues with seantis.reservation 1.1, like unregular gaps.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix small style issues with seantis.reservation 1.1, like unregular gaps.
+  [href]
 
 
 1.3.0 (2014-08-05)

--- a/plonetheme/onegov/resources/sass/components/reservation.scss
+++ b/plonetheme/onegov/resources/sass/components/reservation.scss
@@ -1,7 +1,7 @@
 /* @group seantis.reservation */
 
 /* @group fullcalendar */
-#content {
+.pb-ajax, #content {
     .fc-event-title {
         font-size: 1.1em;
     }
@@ -567,10 +567,11 @@ table.timetable div.timespan div.occupied {
     .searchresults {
         float: left;
         padding-left: 2em;
-    }
 
-    .new-day td {
-        padding-top: 1em;
+        /* have more space in the search results than usual */
+        .new-day td {
+            padding-top: 1.5em;
+        }
     }
 
     @media screen and (max-width: 769px) {
@@ -613,10 +614,11 @@ table.timetable div.timespan div.occupied {
         border-radius: 2px;
         color: white;
         padding: 2px 8px;
+        margin-right: 0.25em;
     }
 
     td {
-        padding: 0 0.5em 0 0;
+        padding-top: 0.5em;
     }
 
     td .result-day {
@@ -626,8 +628,19 @@ table.timetable div.timespan div.occupied {
         float: none;
         min-width: 100px;
         text-align: center;
-        line-height: 1.81em;
-        margin-top: 6px;
+        line-height: 1.75em;
+        margin: 0;
+    }
+
+    .new-day td {
+        padding-top: 1em;
+    }
+
+    tr td:first-child {
+        padding-right: 9px;
+    }
+    tr td:last-child {
+        padding-left: 5px;
     }
 }
 


### PR DESCRIPTION
Those are not critical fixes, so I don't require a new release or anything.
