### PR TITLE
Also include linguaplone / multilingual languageselector into theme.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Also include linguaplone / multilingual languageselector into theme.
+  [Julian Infanger]
+
 - Highlight accessibility link for search correctly.
   [Julian Infanger]
 

--- a/plonetheme/onegov/resources/rules.xml
+++ b/plonetheme/onegov/resources/rules.xml
@@ -46,7 +46,7 @@
     <replace css:content="#portal-globalnav" css:theme="#portal-globalnav" />
     <replace css:content="#portal-searchbox" css:theme="#portal-searchbox" />
     <replace css:content="#portal-personaltools-wrapper" css:theme="#portal-personaltools-wrapper" />
-    <replace css:content="#portal-languageselector-wrapper" css:theme="#portal-languageselector-wrapper" />
+    <replace css:content="#portal-languageselector" css:theme="#portal-languageselector" />
 
     <replace css:content-children="#portal-topactions" css:theme-children="#portal-topactions" />
 


### PR DESCRIPTION
Fixes #140 
The theme includes the `ftw.subsite`'s language selector.
This pull request let the theme deal with `Products.LinugaPlone` and `plone.app.multilingual`

@maethu would you please take a l:eyes:k?
