### PR TITLE
Added test which generates the css file

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Added test which generates the css file, to make sure there is no syntax error.
+  [Julian Infanger]
+
 - Added styles for new ftw.slider release.
   [Julian Infanger]
 

--- a/plonetheme/onegov/tests/test_customstyles_adapter.py
+++ b/plonetheme/onegov/tests/test_customstyles_adapter.py
@@ -75,3 +75,7 @@ class TestICustomStylesAdapter(MockTestCase):
         self.replay()
 
         adapter.set('css.body-background', 'blue')
+
+    def test_scss_generation_doesnt_fail(self):
+        view = self.portal.unrestrictedTraverse('customstyles_css')
+        self.assertTrue(len(view.generate_css()) > 0)


### PR DESCRIPTION
to make sure there is no syntax error.
@jone as we discussed
![bildschirmfoto 2014-08-14 um 13 14 09](https://cloud.githubusercontent.com/assets/157533/3919170/2a5dcbea-23a4-11e4-805b-5d6dd0b3b2ab.png)
