### PR TITLE
Fix double border in navigation without children.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Fix double border in navigation without children.
+  [Julian Infanger]
+
 - Remove ftw.slider styles.
   This is now defined in the ftw.slider package.
   [Julian Infanger]

--- a/plonetheme/onegov/resources/sass/components/base.scss
+++ b/plonetheme/onegov/resources/sass/components/base.scss
@@ -341,10 +341,12 @@ a,
     }
   }
   & .current {
-    border-bottom: 1px solid $lightgray2;
     padding: 0.5em 0.5em;
     @include gradient($navigation-gradient-from, $navigation-gradient-to);
     font-weight: bold;
+    + li.child {
+      border-top: 1px solid $lightgray2;
+    }
   }
   & .parent, & .sibling {
     border-bottom: 1px solid $lightgray2;


### PR DESCRIPTION
@jone 
**from**
![bildschirmfoto 2014-08-15 um 14 00 03](https://cloud.githubusercontent.com/assets/157533/3932895/bdd8cd1e-2473-11e4-8bbc-6f1af44c27f9.png)

**to**
![bildschirmfoto 2014-08-15 um 13 59 45](https://cloud.githubusercontent.com/assets/157533/3932896/c4bb539a-2473-11e4-83a7-1d7ee965f758.png)

( CSS + => sibling selector )
