### PR TITLE
Flyout navigation style

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Fixed flyout navigation styles.
+  [Julian Infanger]
+
 - Fix double border in navigation without children.
   [Julian Infanger]
 

--- a/plonetheme/onegov/resources/sass/components/overrides.scss
+++ b/plonetheme/onegov/resources/sass/components/overrides.scss
@@ -99,7 +99,7 @@ ul.mobileNavigation {
   position: relative;
   z-index: 3;
   border: 1px solid $global-navigation-flyout-border;
-  padding: 1em 1em 0 1em;
+  padding: 0.25em 1em 0 1em;
   margin: 0;
   position: absolute;
   left: 0;
@@ -113,7 +113,10 @@ ul.mobileNavigation {
     margin: 0;
   }
   & li.directLink {
-    border-bottom: 1px solid $global-navigation-flyout-border;
+    font-weight: bold;
+    + li {
+      border-top: 1px solid $lightgray2;
+    }
   }
   & a {
     text-decoration: none;


### PR DESCRIPTION
optimize flyout navigation styling:
- Don't use that much space before the navigation children
- Border below "direct to" link should be in a lighter gray
- "Direct to" link should be bold
  ![bildschirmfoto 2014-08-15 um 13 46 57](https://cloud.githubusercontent.com/assets/157533/3932824/550e05f2-2472-11e4-8bb0-e401711412ba.png)
