### PR TITLE
Show required markers in IE

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Show required markers in IE.
+  [msom]
 
 
 1.4.1 (2014-12-11)

--- a/plonetheme/onegov/resources/sass/components/form.scss
+++ b/plonetheme/onegov/resources/sass/components/form.scss
@@ -205,7 +205,6 @@ input#title {
 div.overlay .field label .required,
 #form .field label .required,
 .formQuestion .required {
-  visibility: hidden;
   font-size: 1px;
   color: transparent;
 }
@@ -214,7 +213,6 @@ div.overlay .field label .required:after,
 #sendto_form .fieldRequired:before,
 .formQuestion .required:after {
   font-size: $font-size;
-  visibility: visible;
   content: "■";
   color: #FF0000;
 }


### PR DESCRIPTION
See #165

IE ignores the visibility:visible of a pseudo element, if the element itself is hidden. I don't think there is a really satisfying solution for this problem.