### PR TITLE
Implement check, if load_flyout_children actually return a flyout navigation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,10 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement check, if load_flyout_children actually return a flyout navigation.
+  This fixes a possible infinite loop, if load_flyout_children accidentally returns
+  the whole site.
+  [mathias.leimgruber]
 
 
 1.5.2 (2015-04-14)

--- a/plonetheme/onegov/resources/js/onegov.js
+++ b/plonetheme/onegov/resources/js/onegov.js
@@ -10,6 +10,11 @@ function close_opened_breadcrumbs(element) {
   });
 }
 
+function valid_response(data) {
+  // It's possible that we do no get what we expect.
+  return $(data).is('ul.flyoutChildren');
+}
+
 jQuery(function($) {
 
   var load_flyout_children = function(indicator, open) {
@@ -27,7 +32,7 @@ jQuery(function($) {
         type : 'GET',
         url : me.attr('href') + '/load_flyout_children',
         success : function(data, textStatus, XMLHttpRequest) {
-          if (textStatus == 'success') {
+          if (textStatus == 'success' && valid_response(data)) {
             var result = $(data);
             result.hide();
             parent.removeClass('loading');
@@ -86,7 +91,7 @@ jQuery(function($) {
         url : obj.attr('href') + '/load_flyout_children',
         data: {breadcrumbs: true},
         success : function(data, textStatus, XMLHttpRequest) {
-          if (textStatus === 'success') {
+          if (textStatus === 'success' && valid_response(data)) {
             if (data.length > 0) {
               if ($(data).hasClass('children') && $(data).is('ul')) {
                 obj.after('<a href="'+obj.attr('href')+'" class="loadChildren" tabindex="-1">▼</a>');


### PR DESCRIPTION
Fixes #171 

Important part of the issue


> The beforetraverse hook in iw.rejectanonymous raises Unauthorized, which redirects to the login page (if not allready logged in).

> The load_flyout_children now gets the login_form (not 401), on the login form there are tabs and everything starts again.... and again... and again, well you experienced this :wink:

@jone 