### PR TITLE
Fixed tabbedview print.css.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.5.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed tabbedview print.css.
+  [lknoepfel]
 
 
 1.5.3 (2015-04-23)

--- a/plonetheme/onegov/resources/css/print.css
+++ b/plonetheme/onegov/resources/css/print.css
@@ -45,7 +45,21 @@ a, a:hover, a:visited, a:active {
 }
 /*Elements to hide*/
 
-#portal-topactions, #portal-languageselector-wrapper, #portal-personaltools-wrapper, #portal-globalnav, #portal-searchbox, #breadcrumbs-wrapper, #column-navigation, #column-sidebar, #footer, #banner-image, .documentEditable #edit-bar, #addResponse, .portletActionsWrapper, #dashboard-add-portlet, form {
+#portal-topactions,
+#portal-languageselector-wrapper,
+#portal-personaltools-wrapper,
+#portal-globalnav,
+#portal-searchbox,
+#breadcrumbs-wrapper,
+#column-navigation,
+#column-sidebar,
+#footer,
+#banner-image,
+.documentEditable #edit-bar,
+#addResponse,
+.portletActionsWrapper,
+#dashboard-add-portlet,
+#tabbedview-body .actionMenuContent {
     display: none !important;
 }
 .sliderText {


### PR DESCRIPTION
 - Added rule `#tabbedview-body .actionMenuContent` to hide "Als Standard-Tab verwenden" actions.
 - Removed `form` rule as it hid the ext-js content in tabbedview.

![screen shot 2015-05-07 at 12 34 06](https://cloud.githubusercontent.com/assets/1375745/7513598/ce9fb55a-f4b5-11e4-97b8-654b535ed18d.png)
![screen shot 2015-05-07 at 12 34 23](https://cloud.githubusercontent.com/assets/1375745/7513600/d0c7d1dc-f4b5-11e4-8dac-2e0474a0a2e8.png)

@bierik @maethu 