### PR TITLE
Do not reset the plone app imaging allowed_sizes property.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.5.4 (unreleased)
 ------------------
 
+- Do not reset the plone app imaging allowed_sizes property.
+  This it not nice!
+
 - Add new filter form mockup. Check `filter.html`.
   [mathias.leimgruber]
 

--- a/plonetheme/onegov/profiles/default/propertiestool.xml
+++ b/plonetheme/onegov/profiles/default/propertiestool.xml
@@ -2,7 +2,7 @@
 <object name="portal_properties" meta_type="Plone Properties Tool">
   <object name="imaging_properties" meta_type="Plone Property Sheet">
     <property name="title">Image handling properties</property>
-    <property name="allowed_sizes" type="lines">
+    <property name="allowed_sizes" type="lines" purge="False">
       <element value="large 768:768"/>
       <element value="preview 400:400"/>
       <element value="mini 200:200"/>


### PR DESCRIPTION
@jone 
That's kind of not nice, to reset this property :exclamation: 

