### PR TITLE
Yet another bugfix for the breadcrump flyout navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Yet another bugfix for the breadcrump flyout navigation.
+  The "noChildren" class was missing on elements without children.
+  [mathias.leimgruber]
 
 
 1.6.1 (2015-05-26)

--- a/plonetheme/onegov/resources/js/onegov.js
+++ b/plonetheme/onegov/resources/js/onegov.js
@@ -92,18 +92,16 @@ jQuery(function($) {
         data: {breadcrumbs: true},
         success : function(data, textStatus, XMLHttpRequest) {
           if (textStatus === 'success' && valid_response(data)) {
-            if (data.length > 0) {
-              if ($(data).hasClass('children') && $(data).is('ul')) {
-                obj.after('<a href="'+obj.attr('href')+'" class="loadChildren" tabindex="-1">▼</a>');
-                obj.after(data);
-              }
-              else {
-                obj.addClass('noChildren');
-              }
+            if ($(data).hasClass('children') && $(data).is('ul')) {
+              obj.after('<a href="'+obj.attr('href')+'" class="loadChildren" tabindex="-1">▼</a>');
+              obj.after(data);
             }
             else {
               obj.addClass('noChildren');
             }
+          }
+          else {
+            obj.addClass('noChildren');
           }
         }
       });


### PR DESCRIPTION
The "noChildren" class was missing on elements without children.

This also removes one `if`, which is good...