### PR TITLE
Replace `jQuery.live` with `jQuery.delegate`

### DIFF
--- a/plonetheme/onegov/resources/js/onegov.js
+++ b/plonetheme/onegov/resources/js/onegov.js
@@ -152,7 +152,7 @@ jQuery(function($) {
     }
   });
 
-  $('#portal-breadcrumbs .flyoutBreadcrumbs a.loadChildren').live('click', function(e){
+  $('#portal-breadcrumbs').delegate('.flyoutBreadcrumbs a.loadChildren', 'click', function(e){
     e.preventDefault();
     var me = $(this);
     var parent = me.parent();

--- a/plonetheme/onegov/resources/js/onegov.js
+++ b/plonetheme/onegov/resources/js/onegov.js
@@ -17,7 +17,7 @@ function valid_response(data) {
 
 jQuery(function($) {
 
-   var load_flyout_grandchildren = function(indicator, open) {       
+   var load_flyout_grandchildren = function(indicator, open) {
       var me = indicator.children("a:first");
       var parent = me.parent('li');
 
@@ -49,7 +49,7 @@ jQuery(function($) {
         parent.toggleClass('flyoutActive');
       }
   };
-    
+
   var load_flyout_children = function(indicator, open) {
     var me = indicator;
     var parent = me.parent('.wrapper').parent('li');
@@ -79,7 +79,7 @@ jQuery(function($) {
                 }, function(e){
                   e.preventDefault();
                   load_flyout_grandchildren($(this), false);
-                });   
+                });
             }
           }
         }


### PR DESCRIPTION
Fixes https://github.com/OneGov/plonetheme.onegov/issues/181

jQuery live has been removed since 1.9. jQuery delegate is still available in the most recent version (2.1.4).