### PR TITLE
Pin "z3c.unconfigure" (fixes failing test setup).

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -7,7 +7,7 @@ package-name = plonetheme.onegov
 
 
 [versions]
-# ftw.solr 1.1.2 is not compatible
+ftw.solr = 1.4.4
 collective.solr = 3.0
 z3c.form = 3.0.5
 ftw.subsite = 1.4.3

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -11,3 +11,4 @@ package-name = plonetheme.onegov
 collective.solr = 3.0
 z3c.form = 3.0.5
 ftw.subsite = 1.4.3
+z3c.unconfigure = 1.0.1


### PR DESCRIPTION
This fixes an error during the buildout where "z3c.unconfigure" wants to install a newer version of "zope.configuration" causing a version conflict:

Error: The requirement ('zope.configuration>=3.8.0') is not allowed by your [versions] constraint (3.7.4)