### PR TITLE
Fix broken print results for simplelayout pages.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Fix broken print result for simplelayout pages
+  [Kevin Bieri]
+
 - Add styling for ftw.books TinyMCE footnote plugin.
   (Ported from 1.6.3) [jone]
 

--- a/plonetheme/onegov/resources/sass/components/base.scss
+++ b/plonetheme/onegov/resources/sass/components/base.scss
@@ -843,6 +843,16 @@ div.ListingBlock div.gallery .sl-img-wrapper img {
   margin: auto;
 }
 
+.simplelayout-block-wrapper {
+  &:before, &:after {
+   content: "";
+   display: table;
+  }
+  &:after {
+    clear: both;
+  }
+}
+
 /* @end */
 
 /* @group to_top link */


### PR DESCRIPTION
Fixes https://extranet.4teamwork.ch/support/zug/maintlog/10949

Use the clearfix hack from https://css-tricks.com/snippets/css/clear-fix/ to
display the blocks under each other by breaking the float.

Previous attempt in https://github.com/4teamwork/izug.organisation/pull/908 but this only affected `izug.organisation` so the fix has been moved to `plonetheme.onegov` to fix both `izug.organisation` and `izug.onegov`. https://github.com/4teamwork/izug.organisation/pull/908 may be reverted.