### PR TITLE
Display contenttype icons in plonebrowser

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.6.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Display contenttype icons in plonebrowser (backport of #195).
+  [Kevin Bieri]
 
 
 1.6.4 (2016-07-19)

--- a/plonetheme/onegov/resources/css/plonebrowser_icons.css
+++ b/plonetheme/onegov/resources/css/plonebrowser_icons.css
@@ -1,0 +1,311 @@
+.contenttype-blog:before,
+.contenttype-blogcategory:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "< ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-book:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "? ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-textblock:before,
+.contenttype-paragraph:before,
+.contenttype-graphicblock:before,
+.contenttype-htmlblock:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "I ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-contact:before,
+.contenttype-ftw_contact:before,
+.contenttype-member:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "\\ ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-poodle:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "a ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-document:before,
+.contenttype-contentpage:before,
+.contenttype-ftw-topics-topic:before,
+.contenttype-page:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: " ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-meeting-item:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "K ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-billboardcategory:before,
+.contenttype-newsfolder:before,
+.contenttype-eventfolder:before,
+.contenttype-homefolder:before,
+.contenttype-tabbedviewfolder:before,
+.contenttype-folder:before,
+.contenttype-ftw-topics-topictree:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "] ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-banner:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "X ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-link:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: " ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.link-mailto a:before,
+.contenttype-ftw_mail:before,
+.contenttype-mail:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: ". ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-news:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "a ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-news-item:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "a ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-event:before,
+.contenttype-plone-app-event-dx-event:before,
+.contenttype-eventpage:before,
+.contenttype-meeting:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "e ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-ticket:before,
+.contenttype-poiissue:before,
+.contenttype-task:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "8 ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-workspace:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "% ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-remark:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "E ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-billboardad:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: ": ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-ticket-box:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "F ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-chapter:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "# ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-table:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "L ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-classificationitem:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: " ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-blogentry:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "N ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-formfolder:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: " ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-subsite:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "Y ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-listingblock:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "I ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-addressblock:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "I ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-refegovservice:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: " ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-shopitemblock:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "H ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-collection:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "F ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+/* seantis.dir.base and seantis.dir.contacts */
+.contenttype-seantis-dir-contacts-directory:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "F ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-seantis-dir-contacts-item:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "_ ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-seantis-dir-contacts-contact:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+/* ftw.shop */
+.contenttype-supplier:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "8 ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-shopcategory:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "7 ";
+  white-space: nowrap;
+  line-height: 1em;
+}
+
+.contenttype-shopitem:before {
+  font-family: "icomoon";
+  font-size: 1em;
+  content: "H ";
+  white-space: nowrap;
+  line-height: 1em;
+}

--- a/plonetheme/onegov/resources/rules.xml
+++ b/plonetheme/onegov/resources/rules.xml
@@ -4,6 +4,16 @@
     xmlns:css="http://namespaces.plone.org/diazo/css"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
+    <rules css:if-content="body#plonebrowser">
+    <replace css:content="head">
+        <head>
+            <xsl:apply-templates select="//head/*" mode="raw"/>
+            <link rel="stylesheet" type="text/css" href="++theme++plonetheme.onegov/css/plonebrowser_icons.css" />
+        </head>
+    </replace>
+
+    </rules>
+
   <!-- Rules applying to standard Plone pages -->
   <rules css:if-content="#visual-portal-wrapper">
 


### PR DESCRIPTION
Register CSS containing contenttype icons in the HEAD section of the plonebrowser using diazo rules.

This is a backport of #195 to the 1.6.x branch.