### PR TITLE
Show the flyout even if the object has no children.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
+- Show the flyout if the object has no children (does not apply to breadcrumbs).
+  [mbaechtold]
+
 - Implement a cached flyout menu.
   [mathias.leimgruber]
 

--- a/plonetheme/onegov/browser/flyout.pt
+++ b/plonetheme/onegov/browser/flyout.pt
@@ -1,11 +1,10 @@
 <tal:nav
     tal:define="nodes view/nodes"
     tal:attributes="id string:nav_${view/context/getId}"
-    tal:condition="nodes"
     i18n:domain="plonetheme.onegov">
 
     <ul tal:attributes="class python:view.is_breadcrumb and 'children' or 'flyoutChildren'"
-        arai="menu">
+        aria="menu">
         <li tal:condition="not:view/is_breadcrumb">
             <a role="menuitem"
                class="separator directLink"

--- a/plonetheme/onegov/browser/navigation.py
+++ b/plonetheme/onegov/browser/navigation.py
@@ -43,7 +43,7 @@ class LoadFlyoutChildren(BrowserView):
         self.update()
         self.set_response_headers()
 
-        if len(self.nodes):
+        if len(self.nodes) or not self.is_breadcrumb():
             return self.template()
         else:
             return ""

--- a/plonetheme/onegov/tests/test_load_flyout.py
+++ b/plonetheme/onegov/tests/test_load_flyout.py
@@ -48,6 +48,21 @@ class TestFyloutView(TestCase):
                          browser.css('.level1 a').first.attrib['href'])
 
     @browsing
+    def test_direct_link_without_children(self, browser):
+        """
+        This test makes sure that the direct link is shown even if
+        the context has no children.
+        """
+        create(Builder('folder'))
+
+        browser.login().visit(view='load_flyout_children')
+
+        self.assertTrue(
+            browser.css('.directLink'),
+            'Direct link is not there but it should.'
+        )
+
+    @browsing
     def test_markup_without_direct_link_for_breadcrumbs(self, browser):
         # create a folder, otherwise the breadcrumbs are empty (test below)
         create(Builder('folder'))


### PR DESCRIPTION
This is needed to show the "direct to..." link. Otherwise the content cannot be accessed.

This does not apply to the flout of the breadcrumbs.