### PR TITLE
Some modification on global tabs styles after changing the font size of the global tabs

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
+- Fix responsive behavior of global tabs.
+  [mathias.leimgruber]
+
 - Change padding of global tabs - allow more tabs on one line.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change padding of global tabs - allow more tabs on one line.
+  [mathias.leimgruber]
 
 
 3.0.0 (2017-02-09)

--- a/plonetheme/onegov/resources/sass/components/base.scss
+++ b/plonetheme/onegov/resources/sass/components/base.scss
@@ -307,10 +307,6 @@ a,
   }
 }
 #portal-globalnav li.selected {
-  padding-bottom: 1em;
-  /* there should not be a border for now, let this as hint if you like to enable this. */
-  /* border-bottom: 5px solid $global-navigation-border-color-active; */
-  margin-bottom: -5px;
   & > .wrapper > a{
     color: $global-navigation-color-selected;
     &:after {

--- a/plonetheme/onegov/resources/sass/components/base.scss
+++ b/plonetheme/onegov/resources/sass/components/base.scss
@@ -278,7 +278,7 @@ a,
     float: left;
     & .wrapper {
       white-space: nowrap;
-      padding: 1em 1em 0.7em 1em;
+      padding: 1em .5em 0.7em .5em;
       margin: 1px;
       margin-bottom: 0;
     }


### PR DESCRIPTION
After release 3.0.0 the font size has been changed from 18px to 22px because of readability (accessibility)

This means the tabs take now far more space than before:
- [x] Change the the padding (right/left) of global tabs
Before: 
<img width="782" alt="screen shot 2017-04-03 at 09 47 25" src="https://cloud.githubusercontent.com/assets/437933/24599903/99abea9a-1852-11e7-9f02-7ef781a0cab6.png">
After:
<img width="870" alt="screen shot 2017-04-03 at 09 47 39" src="https://cloud.githubusercontent.com/assets/437933/24599907/9f082ac6-1852-11e7-8790-5a1cc12df452.png">


- [x] Fix responsive behavior
Before:
<img width="694" alt="screen shot 2017-04-03 at 09 41 47" src="https://cloud.githubusercontent.com/assets/437933/24599914/a597603c-1852-11e7-8382-6ef7cb0e2e8a.png">
After:
<img width="650" alt="screen shot 2017-04-03 at 09 48 49" src="https://cloud.githubusercontent.com/assets/437933/24599936/bfd6cb0e-1852-11e7-9fcf-70f175295a12.png">
