### PR TITLE
Fix alignment of multiline top navigation.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix alignment of multiline top navigation.
+  [Kevin Bieri]
 
 
 3.0.1 (2017-04-19)
@@ -22,7 +23,7 @@ Changelog
 
 - Replace `portletItem` with `portletContent` in selectors.
   The new static text portlet structure, no longer has a portletItem class.
-  [mathias.leimgruber] 
+  [mathias.leimgruber]
 
 - Several more major changes to the UI for accessibility reasons:
   - Change base font-size to 16px, instead of 13px.
@@ -31,7 +32,7 @@ Changelog
   - Change global section font-size to 22px, instead of 18px
 
   Those changes makes the Website generally more readable. The main Issue with the prev. settings was the contrast between the background-color and
-  the font-color. With a size of 13px the contrast was not good enough. 
+  the font-color. With a size of 13px the contrast was not good enough.
   With a a font-size of 16px the contrast is fine according to AAA
   without changing the colors.
 

--- a/plonetheme/onegov/resources/sass/components/base.scss
+++ b/plonetheme/onegov/resources/sass/components/base.scss
@@ -278,7 +278,7 @@ a,
     float: left;
     & .wrapper {
       white-space: nowrap;
-      padding: 1em .5em 0.7em .5em;
+      padding: 1em 1em 0.7em 0;
       margin: 1px;
       margin-bottom: 0;
     }


### PR DESCRIPTION
Closes https://extranet.4teamwork.ch/support/zug/maintlog/11162

The padding on both sides of the navigation elements does not allow
a proper vertical alignment when having multiline top navigation.

![screen shot 2017-04-20 at 11 49 46](https://cloud.githubusercontent.com/assets/1637820/25224944/339c35c2-25c0-11e7-86d8-7a9b06011b04.png)
![screen shot 2017-04-20 at 11 53 39](https://cloud.githubusercontent.com/assets/1637820/25224945/339d0a6a-25c0-11e7-858d-86327e90e541.png)
