### PR TITLE
Rewrite tests using "ftw.testbrowser".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Rewrite tests using "ftw.testbrowser", drop dependency on "ftw.testing[splinter]". [mbaechtold]
 
 
 3.0.2 (2017-04-20)

--- a/plonetheme/onegov/testing.py
+++ b/plonetheme/onegov/testing.py
@@ -2,8 +2,8 @@ from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
 from ftw.testing import ComponentRegistryLayer
-from ftw.testing import FunctionalSplinterTesting
 from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
@@ -48,7 +48,7 @@ THEME_INTEGRATION_TESTING = IntegrationTesting(
     bases=(THEME_FIXTURE, ),
     name='plonetheme.onegov:integration')
 
-THEME_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+THEME_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(THEME_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="plonetheme.onegov:functional")

--- a/plonetheme/onegov/tests/pages.py
+++ b/plonetheme/onegov/tests/pages.py
@@ -1,25 +1,29 @@
-from ftw.testing import browser
-from ftw.testing.pages import Plone
+from ftw.testbrowser import browser as default_browser
+from plone import api
 
 
-class SearchBox(Plone):
+class SearchBox(object):
+
+    def __init__(self, browser=default_browser):
+        self.browser = browser
+        self.portal = api.portal.get()
 
     @property
     def search_field_placeholder(self):
         xpr = '#portal-searchbox input[name=SearchableText]'
-        return browser().find_by_css(xpr).first['placeholder']
+        return self.browser.css(xpr).first.attrib['placeholder']
 
-    @property
+    @ property
     def form_action(self):
         xpr = '#portal-searchbox form'
-        return browser().find_by_css(xpr).first['action']
+        return self.browser.css(xpr).first.attrib['action']
 
     @property
     def has_solr(self):
         xpr = '#portal-searchbox form.has-solr'
-        return len(browser().find_by_css(xpr)) > 0
+        return len(self.browser.css(xpr)) > 0
 
     @property
     def no_solr(self):
         xpr = '#portal-searchbox form.no-solr'
-        return len(browser().find_by_css(xpr)) > 0
+        return len(self.browser.css(xpr)) > 0

--- a/plonetheme/onegov/tests/test_customstyles_form.py
+++ b/plonetheme/onegov/tests/test_customstyles_form.py
@@ -50,8 +50,7 @@ class TestCustomstylesForm(TestCase):
         portal.manage_permission('plonetheme.onegov: Manage Styles',
                                  roles=[], acquire=False)
         transaction.commit()
-
-        with self.assertRaises(Unauthorized):
+        with browser.expect_unauthorized():
             browser.login().visit(view='customstyles_form')
 
     @browsing

--- a/plonetheme/onegov/tests/test_rendering.py
+++ b/plonetheme/onegov/tests/test_rendering.py
@@ -1,5 +1,4 @@
-from ftw.testing import browser
-from ftw.testing.pages import Plone
+from ftw.testbrowser import browsing
 from plonetheme.onegov.testing import THEME_FUNCTIONAL_TESTING
 from unittest2 import TestCase
 
@@ -8,14 +7,16 @@ class TestReindering(TestCase):
 
     layer = THEME_FUNCTIONAL_TESTING
 
-    def test_theme_is_rendered_anonymous(self):
-        Plone().visit_portal()
+    @browsing
+    def test_theme_is_rendered_anonymous(self, browser):
+        browser.open()
         self.assertTrue(
-            browser().find_by_css('#page-wrapper'),
+            browser.css('#page-wrapper'),
             'Could not find #page-wrapper - was the theme rendered?')
 
-    def test_theme_is_rendered_logged_in(self):
-        Plone().login().visit_portal()
+    @browsing
+    def test_theme_is_rendered_logged_in(self, browser):
+        browser.login().open()
         self.assertTrue(
-            browser().find_by_css('#page-wrapper'),
+            browser.css('#page-wrapper'),
             'Could not find #page-wrapper - was the theme rendered?')

--- a/plonetheme/onegov/tests/test_search.py
+++ b/plonetheme/onegov/tests/test_search.py
@@ -2,7 +2,7 @@ from Products.Five.browser import BrowserView
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.solr.interfaces import IFtwSolrLayer
-from ftw.testing.pages import Plone
+from ftw.testbrowser import browsing
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
@@ -54,8 +54,9 @@ class TestSeachBoxViewlet(TestCase):
 
         self.assertTrue(viewlet.has_solr())
 
-    def test_default_plone_placeholder_is_used_by_deafult(self):
-        Plone().visit_portal()
+    @browsing
+    def test_default_plone_placeholder_is_used_by_deafult(self, browser):
+        browser.open()
         default_placeholder = translate('title_search_site',
                                         default='Search this site',
                                         domain='plone',
@@ -63,21 +64,24 @@ class TestSeachBoxViewlet(TestCase):
         self.assertEquals(default_placeholder,
                           SearchBox().search_field_placeholder)
 
-    def test_customize_placeholder_by_setting_property(self):
+    @browsing
+    def test_customize_placeholder_by_setting_property(self, browser):
         self.portal._setProperty('search_label', 'Search example.com',
                                  'string')
         transaction.commit()
-        Plone().visit_portal()
+        browser.open()
         self.assertEquals('Search example.com',
                           SearchBox().search_field_placeholder)
 
-    def test_empty_placeholder_by_setting_property(self):
+    @browsing
+    def test_empty_placeholder_by_setting_property(self, browser):
         self.portal._setProperty('search_label', '', 'string')
         transaction.commit()
-        Plone().visit_portal()
+        browser.open()
         self.assertEquals('', SearchBox().search_field_placeholder)
 
-    def test_placeholder_property_can_be_overriden_on_any_context(self):
+    @browsing
+    def test_placeholder_property_can_be_overriden_on_any_context(self, browser):
         self.portal._setProperty('search_label', 'search portal', 'string')
         folder = create(Builder('folder'))
         folder._setProperty('search_label', 'search folder', 'string')
@@ -85,28 +89,31 @@ class TestSeachBoxViewlet(TestCase):
 
         placeholders = {}
 
-        Plone().login().visit_portal()
+        browser.login().open()
         placeholders['portal'] = SearchBox().search_field_placeholder
-        Plone().visit(folder)
+        browser.visit(folder)
         placeholders['folder'] = SearchBox().search_field_placeholder
 
         self.assertEquals({'portal': 'search portal',
                            'folder': 'search folder'},
                           placeholders)
 
-    def test_placeholder_property_is_inherited(self):
+    @browsing
+    def test_placeholder_property_is_inherited(self, browser):
         self.portal._setProperty('search_label', 'search site', 'string')
         folder = create(Builder('folder'))
-        Plone().login().visit(folder)
+        browser.login().visit(folder)
         self.assertEquals('search site', SearchBox().search_field_placeholder)
 
-    def test_form_action_is_page_template_when_solr_disabled(self):
-        Plone().login().visit_portal()
+    @browsing
+    def test_form_action_is_page_template_when_solr_disabled(self, browser):
+        browser.login().open()
         self.assertEquals('http://nohost/plone/search',
                           SearchBox().form_action)
 
-    def test_no_solr_cssclass_present_when_solr_disabled(self):
-        Plone().login().visit_portal()
+    @browsing
+    def test_no_solr_cssclass_present_when_solr_disabled(self, browser):
+        browser.login().open()
         self.assertTrue(SearchBox().no_solr,
                         'The no-solr class is missing on the search <form>')
         self.assertFalse(SearchBox().has_solr,
@@ -124,13 +131,15 @@ class TestSeachBoxViewletWithSolr(TestCase):
         mark_layer(portal, BeforeTraverseEvent(portal, request))
         transaction.commit()
 
-    def test_form_action_is_view_when_solr_enabled(self):
-        Plone().login().visit_portal()
+    @browsing
+    def test_form_action_is_view_when_solr_enabled(self, browser):
+        browser.login().open()
         self.assertEquals('http://nohost/plone/@@search',
                           SearchBox().form_action)
 
-    def test_has_solr_cssclass_present_when_solr_enabled(self):
-        Plone().login().visit_portal()
+    @browsing
+    def test_has_solr_cssclass_present_when_solr_enabled(self, browser):
+        browser.login().open()
         self.assertTrue(SearchBox().has_solr,
                         'The has-solr class is missing on the search <form>')
         self.assertFalse(SearchBox().no_solr,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ tests_require = [
     'ftw.solr',
     'ftw.testbrowser',
     'ftw.subsite',
-    'ftw.testing [splinter]',
+    'ftw.testing',
     'plone.app.testing',
     'plone.resource',
     'pyquery',


### PR DESCRIPTION
This is needed because "ftw.testing" 1.12.0 removed the "splinter" extra.