### PR TITLE
Fix mobile language toggle.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 3.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix mobile language toggle. [mbaechtold]
 
 
 3.1.0 (2017-12-13)

--- a/plonetheme/onegov/resources/js/onegov.js
+++ b/plonetheme/onegov/resources/js/onegov.js
@@ -122,7 +122,7 @@ jQuery(function($) {
     var me = $(this);
     close_opened(me);
     me.toggleClass('selected');
-    $('#portal-languageselector actionMenuContent').toggle();
+    $('#portal-languageselector .actionMenuContent').toggle();
   });
 
   // breadcrumbs


### PR DESCRIPTION
The bug has been introduced in 2.0.2, causing the mobile language button to no longer open the dropdown containing the language options.