### PR TITLE
Make Diazo theme customizable by using theme-prefixed path to index.html

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 3.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make Diazo theme customizable by using theme-prefixed path to index.html. [tinagerber]
 
 
 3.2.0 (2019-07-04)

--- a/plonetheme/onegov/resources/rules.xml
+++ b/plonetheme/onegov/resources/rules.xml
@@ -17,7 +17,7 @@
   <!-- Rules applying to standard Plone pages -->
   <rules css:if-content="#visual-portal-wrapper">
 
-    <theme href="index.html" />
+    <theme href="++theme++plonetheme.onegov/index.html" />
 
     <!-- Copy standard header tags, including base (very important for
          Plone default pages to work correctly), meta, title and


### PR DESCRIPTION
Goal: We want to be able to customize the theme in a policy project, so that we can add more diazo rules without having to copy the complete rules/index.html
Solution: Prefix the index.html path with the theme path segment.