### PR TITLE
Follow ftw.theming way of compiling scss to fix compilation errors

### DIFF
--- a/plonetheme/onegov/utils.py
+++ b/plonetheme/onegov/utils.py
@@ -1,5 +1,7 @@
 from Products.CMFCore.utils import getToolByName
 from plone import api
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 
 TIMESTAMP_ANNOTATION_KEY = 'customstyles_url_timestamp'
@@ -46,3 +48,8 @@ def get_hostname(request):
     # Remove port
     host = host.split(":")[0].lower()
     return host
+
+
+def is_debug_mode_enabled():
+    registry = getUtility(IRegistry)
+    return registry.records['plone.resources.development'].value


### PR DESCRIPTION
And improved debugging with enabled development mode

I had the case that certain scss files were not compiled. They were in the list of files read and given to the scss package but they were not in the final compiled CSS. I don't know if there is some error in the scss compiler or in the way `plonetheme.onegov` uses its API. With with the extensively tested way of how `ftw.themeing` handles the compilation it works as expected. 
Another advantage of this implementation is that in development mode we get an uncompressed version with comments to the original files as it is in `ftw.theming`.