### PR TITLE
ftw.footer 1.2.0 compatibility.

### DIFF
--- a/plonetheme/onegov/resources/sass/components/base.scss
+++ b/plonetheme/onegov/resources/sass/components/base.scss
@@ -911,6 +911,10 @@ div.ListingBlock div.gallery .sl-img-wrapper img {
   margin-top: 0.5em;
 }
 
+#ftw-footer {
+  padding-top: 0;
+}
+
 /* @end */
 
 /* @group site-actions */


### PR DESCRIPTION
Before:
<img width="1033" alt="Screen Shot 2019-12-17 at 14 02 28" src="https://user-images.githubusercontent.com/437933/70997760-065bef80-20d6-11ea-9ff4-33f453cf9415.png">

After:
<img width="1040" alt="Screen Shot 2019-12-17 at 14 02 33" src="https://user-images.githubusercontent.com/437933/70997759-065bef80-20d6-11ea-9c3a-579cd6219cd0.png">