### PR TITLE
Provide a base tag.

### DIFF
--- a/plonetheme/onegov/tests/test_basetag.py
+++ b/plonetheme/onegov/tests/test_basetag.py
@@ -1,0 +1,15 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.testbrowser import browsing
+from plonetheme.onegov.tests import FunctionalTestCase
+
+
+class TestBaseTagViewlet(FunctionalTestCase):
+
+    @browsing
+    def test_base_tag_has_trailing_slash(self, browser):
+        self.grant('Manager')
+        folder = create(Builder('folder').titled(u'The Folder'))
+        browser.login().open(folder)
+        self.assertEqual({'href': 'http://nohost/plone/the-folder/'},
+                         dict(browser.css('base').first.attrib))

--- a/plonetheme/onegov/viewlets/basetag.py
+++ b/plonetheme/onegov/viewlets/basetag.py
@@ -1,0 +1,9 @@
+from plone.app.layout.viewlets.common import ViewletBase
+
+
+class BaseTagViewlet(ViewletBase):
+
+    template = '<base href="{}" /><!--[if lt IE 7]></base><![endif]-->'
+
+    def index(self):
+        return self.template.format(self.context.absolute_url() + '/')

--- a/plonetheme/onegov/viewlets/configure.zcml
+++ b/plonetheme/onegov/viewlets/configure.zcml
@@ -3,6 +3,15 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:browser="http://namespaces.zope.org/browser">
 
+  <!-- base tag -->
+  <browser:viewlet
+      name="onegov.basetag"
+      manager="plone.app.layout.viewlets.interfaces.IHtmlHead"
+      class=".basetag.BaseTagViewlet"
+      permission="zope2.View"
+      layer="plonetheme.onegov.interfaces.IPlonethemeOneGovLayer"
+      />
+
   <!-- The personal bar -->
   <browser:viewlet
       name="plone.personal_bar"


### PR DESCRIPTION
Plone has removed the base tag. The base tag is used by the browser for generating URLs based on relative paths. In Plone it is possible to get the same resource with and without a trailing slash. When a page contains relative paths (e.g. HTML block) the behavior is incosistent when the page is loaded with or without a trailing slash.

The fix is to simply add the base tag again. Plone 4 used to check whether the content "isPrincipiaFolderish", but since all our content matches this criteria we are always adding a trailing slash.