### PR TITLE
Pattern markspeciallinks-onegov respects registry

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 4.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Respect registry entries to control the markspeciallinks pattern [Nachtalb]
 
 
 4.0.2 (2020-01-31)

--- a/plonetheme/onegov/configure.zcml
+++ b/plonetheme/onegov/configure.zcml
@@ -18,6 +18,7 @@
   <include package=".portlets" />
   <include package=".viewlets" />
   <include package=".exportimport" />
+  <include package=".patterns" />
   <include zcml:condition="installed ftw.lawgiver" file="lawgiver.zcml" />
 
   <i18n:registerTranslations directory="locales" />

--- a/plonetheme/onegov/patterns/configure.zcml
+++ b/plonetheme/onegov/patterns/configure.zcml
@@ -1,0 +1,9 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <adapter
+      for="* * *"
+      factory=".settings.OneGovPatternSettingsAdapter"
+      provides="Products.CMFPlone.interfaces.IPatternsSettings"
+      />
+
+</configure>

--- a/plonetheme/onegov/patterns/settings.py
+++ b/plonetheme/onegov/patterns/settings.py
@@ -1,0 +1,42 @@
+from Products.CMFPlone.interfaces import ILinkSchema
+from Products.CMFPlone.interfaces import IPatternsSettings
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from zope.interface import implementer
+import json
+
+
+@implementer(IPatternsSettings)
+class OneGovPatternSettingsAdapter(object):
+    def __init__(self, context, request, field):
+        self.context = context
+        self.request = request
+        self.field = field
+
+    def __call__(self):
+        return self.mark_special_links()
+
+    def mark_special_links(self):
+        """Settings for plonetheme/onegov/resources/js/pattern.markspeciallinks.js
+
+        Copied from Products.CMFPlone-5.1.6/Products/CMFPlone/patterns/settings.py
+        with adjusted pattern name.
+        """
+        result = {}
+
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(
+            ILinkSchema, prefix="plone", check=False)
+
+        msl = settings.mark_special_links
+        elonw = settings.external_links_open_new_window
+        if msl or elonw:
+            result = {
+                'data-pat-markspeciallinks-onegov': json.dumps(
+                    {
+                        'external_links_open_new_window': elonw,
+                        'mark_special_links': msl
+                    }
+                )
+            }
+        return result


### PR DESCRIPTION
Onegovbox uses its own markspeciallinks pattern and only changes the behaviour of the classes/wrappers. Thus it should still respect the same settings as the default CMFPlone one. 

`ILinkSchema`
- `mark_special_links`
- `external_links_open_new_window`