### PR TITLE
Hide visual clutter on manage-portlets page

### DIFF
--- a/plonetheme/onegov/resources/sass/components/controlpanel/controlpanels.plone.scss
+++ b/plonetheme/onegov/resources/sass/components/controlpanel/controlpanels.plone.scss
@@ -110,3 +110,21 @@ body[class*=-controlpanel] #columns .standalone {
     background-color: #ccc;
   }
 }
+
+// This page duplicates #container in the DOM when a different portlet manager
+// is selected (a plone issue). So we need to hide visual clutter with CSS.
+body.template-topbar-manage-portlets #container #container {
+  #page-wrapper {
+    margin: 0;
+    width: 100%;
+    box-shadow: none;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    border: none;
+    background-color: transparent;
+  }
+
+  #header, #banner-image, #breadcrumbs-wrapper, #portal-topactions {
+    display: none;
+  }
+}


### PR DESCRIPTION
    This page duplicates #container in the DOM when a different portlet manager is selector

    Further resolves https://github.com/4teamwork/izug.organisation/issues/1791

    This is an issue in Plone 5.1 and 5.2