### PR TITLE
Fix main navigation behind folder_contents menu bar

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,7 @@ Changelog
 4.0.3 (unreleased)
 ------------------
 
+- Fix main navigation behind folder_contents menu bar [Nachtalb]
 - Respect registry entries to control the markspeciallinks pattern [Nachtalb]
 
 

--- a/plonetheme/onegov/resources/sass/components/menues.scss
+++ b/plonetheme/onegov/resources/sass/components/menues.scss
@@ -255,5 +255,5 @@ span.arrowDownAlternative {
 /* @end */
 
 .pat-structure .navbar {
-  z-index: 4;
+  z-index: 2;
 }


### PR DESCRIPTION
Before
---
<img width="452" alt="Screenshot 2020-02-05 at 08 31 57" src="https://user-images.githubusercontent.com/9467802/73820538-4ac05d80-47f2-11ea-977b-94f1a8b75030.png">

After
---
<img width="452" alt="Screenshot 2020-02-05 at 08 31 43" src="https://user-images.githubusercontent.com/9467802/73820550-514ed500-47f2-11ea-83e4-55161707e6cd.png">
