### PR TITLE
Fix position of the navbar items

### DIFF
--- a/plonetheme/onegov/resources/sass/components/menues.scss
+++ b/plonetheme/onegov/resources/sass/components/menues.scss
@@ -268,6 +268,7 @@ body.template-folder_contents {
     margin-top: .5em;
     vertical-align: middle;
     display: inline-block;
+    font-size: 12px;
   }
 
   .pat-structure .navbar > a.btn,


### PR DESCRIPTION
Some elements are wrapped in a div which doesn't have the same
font-size as the elements in it. And because the margin is set in em it is
relative to the font size. This resulted in a 1px difference between the
margins causing it to not be aligned in some zoom levels.

![image](https://user-images.githubusercontent.com/9467802/76863938-9427b200-6860-11ea-94ce-99ce7234a9e3.png)
